### PR TITLE
Allow setting object ACL

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -83,6 +83,7 @@ Resources:
             Action:
             - s3:GetObject
             - s3:PutObject
+            - s3:PutObjectAcl
             Resource:
               'Fn::Join':
                 - ''


### PR DESCRIPTION
Ensure that the `PutObject` call can also set the ACL to `public-read` such that it can be consumed by an ics-compatible consumer.